### PR TITLE
Change from event to post

### DIFF
--- a/_posts/2019-03-20-Stammtisch.md
+++ b/_posts/2019-03-20-Stammtisch.md
@@ -1,16 +1,13 @@
 ---
-layout: event
-category: event
+layout: pos
 title: March 2019 - Stammtisch
-rsvp: mailto:maptime.salzburg@gmail.com?subject=March%202019%20Maptime
 ---
 
-On the 20th of March we will have the next Maptime Stammtisch!
+On the 20th of March we had a Maptime Stammtisch! Around 30 people came. Thanks for an evening of great conversation!
 
-**date**: Wednesday, 20th March
+**date**: Wednesday, 20th March 2019
 
 **time**: 19:30h
 
 **place**: [Augustiner Bräu](https://www.augustinerbier.at/), Lindhofstraße 7, 5020 Salzburg
 
-For anyone who is interested in getting involved in planning or shaping future Maptime events, **come 30 minutes earlier** and participate in an informal admin meeting. All are welcome!


### PR DESCRIPTION
Change March event to post to reflect what happened and not advertising the event.